### PR TITLE
Rapidez V5 support + codestyle workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,1 @@
-vendor/rapidez/laravel-coding-standard/.editorconfig
+vendor/rapidez/coding-standards/.editorconfig

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,1 @@
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
-indent_size = 4
-trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false
-
-[*.{yml,yaml}]
-indent_size = 2
+vendor/rapidez/laravel-coding-standard/.editorconfig

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,0 +1,38 @@
+name: analyse
+
+on: ["push", "pull_request"]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*]
+        stability: [prefer-stable]
+        include:
+          - laravel: 12.*
+            testbench: 10.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: Execute phpstan
+        run: php ./vendor/bin/phpstan --memory-limit=1G

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -4,35 +4,22 @@ on: ["push", "pull_request"]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    uses: rapidez/workflows/.github/workflows/analyse.yml@master
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
-        stability: [prefer-stable]
+        php: [8.4, 8.5]
+        laravel: [12.*, 13.*]
+        stability: [prefer-stable, prefer-lowest]
         include:
           - laravel: 12.*
             testbench: 10.*
-
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
-
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Execute phpstan
-        run: php ./vendor/bin/phpstan --memory-limit=1G
+          - laravel: 13.*
+            testbench: 11.*
+    with:
+      os: ${{ matrix.os }}
+      php: ${{ matrix.php }}
+      laravel: ${{ matrix.laravel }}
+      testbench: ${{ matrix.testbench }}
+      stability: ${{ matrix.stability }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,26 +7,10 @@ on:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.release.target_commitish }}
-          token: ${{ secrets.RAPIDEZ_ACTIONS_ACCOUNT_PAT }}
-
-      - name: Generate changelog
-        uses: justbetter/generate-changelogs-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          repository: ${{ github.repository }}
-          sha: ${{ github.head_ref || github.ref_name }}
-
-      - name: Commit CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+    uses: rapidez/workflows/.github/workflows/changelog.yml@master
+    with:
+      repository: ${{ github.repository }}
+      branch: ${{ github.event.release.target_commitish }}
+      ref: ${{ github.head_ref || github.ref_name }}
+      token: ${{ secrets.RAPIDEZ_ACTIONS_ACCOUNT_PAT }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/duster-fix-blame.yml
+++ b/.github/workflows/duster-fix-blame.yml
@@ -8,25 +8,7 @@ on:
 
 jobs:
   duster:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.RAPIDEZ_ACTIONS_ACCOUNT_PAT }}
-
-      - name: "Duster Fix"
-        uses: tighten/duster-action@v2
-        with:
-          args: fix -vvv
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        id: auto_commit_action
-        with:
-          commit_message: Apply fixes from Duster
-          commit_user_name: GitHub Action
-          commit_user_email: actions@github.com
+    uses: rapidez/workflows/.github/workflows/duster-fix-blame.yml@master
+    with:
+      ref: ${{ github.head_ref }}
+      repo-token: ${{ secrets.RAPIDEZ_ACTIONS_ACCOUNT_PAT }}

--- a/.github/workflows/duster-fix-blame.yml
+++ b/.github/workflows/duster-fix-blame.yml
@@ -1,0 +1,32 @@
+name: Duster
+
+# Commits made in here will not trigger any workflows
+# Checkout Duster's documentation for a workaround
+
+on:
+  push:
+
+jobs:
+  duster:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RAPIDEZ_ACTIONS_ACCOUNT_PAT }}
+
+      - name: "Duster Fix"
+        uses: tighten/duster-action@v2
+        with:
+          args: fix -vvv
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit_action
+        with:
+          commit_message: Apply fixes from Duster
+          commit_user_name: GitHub Action
+          commit_user_email: actions@github.com

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -9,18 +9,4 @@ on:
 
 jobs:
   translations:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-          coverage: none
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction
-      - name: Check translations
-        uses: rapidez/laravel-translation-checker@master
+    uses: rapidez/workflows/.github/workflows/translations.yml@master

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,6 @@
     },
     "require-dev": {
         "larastan/larastan": "^3.9",
-        "rapidez/laravel-coding-standard": "^1.0"
+        "rapidez/coding-standards": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.3",
-        "rapidez/core": "^4.0"
+        "rapidez/core": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     },
     "extra": {
         "laravel": {
@@ -34,5 +37,9 @@
                 "VendorName\\Skeleton\\SkeletonServiceProvider"
             ]
         }
+    },
+    "require-dev": {
+        "larastan/larastan": "^3.9",
+        "rapidez/laravel-coding-standard": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "rapidez/core": "^5.0"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - ./vendor/rapidez/laravel-coding-standard/phpstan.neon
+
+parameters:
+    level: 1
+    paths:
+        - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/rapidez/laravel-coding-standard/phpstan.neon
+    - ./vendor/rapidez/coding-standards/phpstan.neon
 
 parameters:
     level: 1

--- a/resources/js/components/Example.vue
+++ b/resources/js/components/Example.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
     render() {
-        return this.$scopedSlots.default({
+        return this?.$slots?.default?.({
             someData: this.someData,
             someMethod: this.someMethod,
             someComputed: this.someComputed,

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,15 +1,17 @@
 // This file will be loaded automatically after installing the package.
 // See: https://github.com/rapidez/rapidez/blob/master/resources/js/app.js
 
-// Vue.component('example', () => import('./components/Example.vue'))
-// -- Or if you don't want it to be lazy loaded:
-// import example from './components/Example.vue'
-// Vue.component('example', example)
+document.addEventListener('vue:loaded', function (event) {
+    const vue = event.detail.vue
 
-document.addEventListener('vue:loaded', function () {
-    // You can access the main Vue instance with "window.app"
+    // import { defineAsyncComponent } from 'vue'
+    // vue.component('example', defineAsyncComponent(() => import('./components/Example.vue')))
+    // -- Or if you don't want it to be lazy loaded:
+    // import example from './components/Example.vue'
+    // vue.component('example', example)
+    // You can access the main Vue instance with "window.app" or "vue"
 
-    // window.app.$on('event-name', () => {
+    // window.$on('event-name', () => {
     //
     // });
 })


### PR DESCRIPTION
Depends on: https://github.com/rapidez/workflows/pull/1
This PR adds V5 support and implements parts of the centralized coding standards.
- PHPstan
- Editorconfig
- Duster

Further changes should be done as the package requires it:
- [Rector](https://github.com/rapidez/laravel-coding-standard#rector)
- [Prettier](https://github.com/rapidez/laravel-coding-standard#prettier-formatter)